### PR TITLE
check_boot_jars: Add OPLUS packages to whitelist

### DIFF
--- a/scripts/check_boot_jars/package_allowed_list.txt
+++ b/scripts/check_boot_jars/package_allowed_list.txt
@@ -283,9 +283,6 @@ org\.codeaurora\.internal.*
 # IFAA Manager used for Alipay and/or WeChat payment
 org\.ifaa\.android\.manager.*
 
-# OPLUS adds
-com\.oplus\..*
-
 # QC adds
 com.qualcomm.qti
 com.quicinc.tcmiface
@@ -294,5 +291,14 @@ com.qualcomm.wfd.service
 org.codeaurora.ims
 org.codeaurora.internal
 qcom.fmradio
+
+###################################################
+# ONEPLUS
+com.oplus.*
+net.oneplus.*
+oplus.*
+vendor.oplus.*
+com.oneplus.*
+vendor.oneplus.*
 
 ###################################################


### PR DESCRIPTION
Error: /out/soong/.intermediates/vendor/oplus/camera/oplus-fwk/oplus-fwk.lahaina/android_common/7bd916565615329d50364be05485f3c9/aligned/oplus-fwk.lahaina.jar contains class file net.oneplus.odm.OpDeviceManagerInjector, whose package name "net.oneplus.odm" is empty or not in the allow list build/soong/scripts/check_boot_jars/package_allowed_list.txt of packages allowed on the bootclasspath.

https://github.com/VoltageOS/build_soong/commit/2a9071a28d3cc1279c23eba317a8538193406984
patch LOS is useless.

